### PR TITLE
Handle long press gesture with gesture recognizer

### DIFF
--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -2,7 +2,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-@interface BDKCollectionIndexView ()
+@interface BDKCollectionIndexView () <UIGestureRecognizerDelegate>
 
 /**
  A component that shows up under the letters to indicate the view is handling a touch or a pan.
@@ -24,21 +24,12 @@
  */
 @property (strong, nonatomic) UITapGestureRecognizer *tapper;
 
+/**
+ A gesture recognizer that handles long presses.
+ */
+@property (strong, nonatomic) UILongPressGestureRecognizer *longPresser;
+
 @property (readonly) CGFloat theDimension;
-
-/**
- Handles events sent by the tap gesture recognizer.
- 
- @param recognizer the sender of the event; usually a UIPanGestureRecognizer.
- */
-- (void)handleTap:(UITapGestureRecognizer *)recognizer;
-
-/**
- Handles events sent by the pan gesture recognizer.
- 
- @param recognizer the sender of the event; usually a UIPanGestureRecognizer.
- */
-- (void)handlePan:(UIPanGestureRecognizer *)recognizer;
 
 /**
  Handles logic for determining which label is under a given touch point, and sets `currentIndex` accordingly.
@@ -76,11 +67,20 @@
     _endPadding = 2;
     _labelColor = [UIColor blackColor];
     _backgroundColor = [UIColor clearColor];
+    
+    SEL handleGestureSelector = @selector(handleGesture:);
 
-    _panner = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+    _panner = [[UIPanGestureRecognizer alloc] initWithTarget:self action:handleGestureSelector];
+    _panner.delegate = self;
     [self addGestureRecognizer:_panner];
-    _tapper = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
+    
+    _tapper = [[UITapGestureRecognizer alloc] initWithTarget:self action:handleGestureSelector];
     [self addGestureRecognizer:_tapper];
+    
+    _longPresser = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:handleGestureSelector];
+    _longPresser.delegate = self;
+    _longPresser.minimumPressDuration = 0.01f;
+    [self addGestureRecognizer:_longPresser];
 
     [self addSubview:self.touchStatusView];
 
@@ -197,26 +197,14 @@
 
 #pragma mark - Gestures
 
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-    UITouch *touch = [touches anyObject];
-    CGPoint touchPoint = [touch locationInView:self];
-    [self setNewIndexForPoint:touchPoint];
-    [self setBackgroundVisibility:YES];
-}
-
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-    [self setBackgroundVisibility:NO];
-}
-
-- (void)handleTap:(UITapGestureRecognizer *)recognizer {
+- (void)handleGesture:(UIGestureRecognizer *)recognizer {
     [self setBackgroundVisibility:!(recognizer.state == UIGestureRecognizerStateEnded)];
     [self setNewIndexForPoint:[recognizer locationInView:self]];
 }
 
-- (void)handlePan:(UIPanGestureRecognizer *)recognizer {
-    [self setBackgroundVisibility:!(recognizer.state == UIGestureRecognizerStateEnded)];
-    CGPoint translation = [recognizer locationInView:self];
-    [self setNewIndexForPoint:translation];
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return gestureRecognizer != _longPresser;
 }
 
 @end


### PR DESCRIPTION
Original implementation of handling long press gesture with ```touchesBegan``` wasn't very reliable in my experience (though it works fine in the example project). Specifically, ```touchesEnded``` method wasn't called after long press in some cases and index view seemed "stuck" with enabled highlighted background (I've tried adding ```touchesCanceled``` method too, but I still wasn't satisfied with the result — the background would blink the moment "long press" turns into pan gesture).

The solution for me was to replace ```touchesBegan``` / ```touchesEnded``` methods with simple ```UILongPressGestureRecognizer``` and one delegate method. Everything else works the same, but background always un-highlights when you lift the finger and gesture handling is more concise now.

P.S. Thanks for the project. 👍