### PR TITLE
Added -[BDKCollectionIndexView reloadData] to force data to be reloaded.

### DIFF
--- a/BDKCollectionIndexView.h
+++ b/BDKCollectionIndexView.h
@@ -65,4 +65,9 @@ typedef NS_ENUM(NSInteger, BDKCollectionIndexViewDirection) {
  */
 - (instancetype)initWithFrame:(CGRect)frame indexTitles:(NSArray *)indexTitles;
 
+/**
+ An instance method to force the index view control to reload the data. Invoked by -setIndexTitles:.
+ */
+- (void)reloadData;
+
 @end

--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -140,6 +140,12 @@
 - (void)setIndexTitles:(NSArray *)indexTitles {
     if (_indexTitles == indexTitles) return;
     _indexTitles = indexTitles;
+	[self reloadData];
+}
+
+- (void)reloadData
+{
+
     [self.indexLabels makeObjectsPerformSelector:@selector(removeFromSuperview)];
     [self buildIndexLabels];
 }


### PR DESCRIPTION
For use when the data source reference hasn't been changed, but its data has.