### PR TITLE
Support dimming label colors upon tint dimming

### DIFF
--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -126,6 +126,18 @@
     }
 }
 
+- (void)tintColorDidChange {
+    if (self.tintAdjustmentMode == UIViewTintAdjustmentModeDimmed) {
+        for (UILabel *label in self.subviews) {
+            label.textColor = [UIColor lightGrayColor];
+        }
+    } else {
+        for (UILabel *label in self.subviews) {
+            label.textColor = self.labelColor;
+        }
+    }
+}
+
 #pragma mark - Properties
 
 - (UIView *)touchStatusView {


### PR DESCRIPTION
The table section index in iOS 7 and 8 automatically desaturates the index colors when an alert appears. BDKCollectionIndexView does not, but this adds support for doing just that. When the tint mode changes to dimmed, the label color changes to light gray. When the alert is dismissed they will go back to the regular label color.