### PR TITLE
Add ability to tap above/below labels to jump to appropriate index

### DIFF
--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -179,14 +179,29 @@
 }
 
 - (void)setNewIndexForPoint:(CGPoint)point {
+    NSInteger newIndex = -1;
+    
     for (UILabel *view in self.indexLabels) {
         if (CGRectContainsPoint(view.frame, point)) {
-            NSUInteger newIndex = view.tag;
-            if (newIndex != _currentIndex) {
-                _currentIndex = newIndex;
-                [self sendActionsForControlEvents:UIControlEventValueChanged];
-            }
+            newIndex = view.tag;
+            break;
         }
+    }
+    
+    if (newIndex == -1) {
+        UILabel *topLabel = self.indexLabels[0];
+        UILabel *bottomLabel = self.indexLabels[self.indexLabels.count - 1];
+        
+        if (point.y < topLabel.frame.origin.y) {
+            newIndex = topLabel.tag;
+        } else if (point.y > bottomLabel.frame.origin.y) {
+            newIndex = bottomLabel.tag;
+        }
+    }
+    
+    if (newIndex != -1 && newIndex != _currentIndex) {
+        _currentIndex = newIndex;
+        [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
 }
 


### PR DESCRIPTION
The table view's section index allows users to tap/swipe above or below the labels to jump to the topmost or bottommost section. This adds that same behavior.