### PR TITLE
Better space distribution

### DIFF
--- a/BDKCollectionIndexView.h
+++ b/BDKCollectionIndexView.h
@@ -40,6 +40,11 @@ typedef NS_ENUM(NSInteger, BDKCollectionIndexViewDirection) {
 @property (readonly) NSString *currentIndexTitle;
 
 /**
+ Preferred font of the index labels. By default, bold system font of size 12.
+ */
+@property (strong, nonatomic) UIFont *font;
+
+/**
  The background color of the "touch status view" that appears when the view is touched.
  */
 @property (strong, nonatomic) UIColor *touchStatusBackgroundColor;

--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -118,28 +118,28 @@
             }
             totalLabelsSize = self.indexLabels.count * labelSize.width;
             
-            while (totalLabelsSize > self.frame.size.width) {
+            while (totalLabelsSize > self.bounds.size.width) {
                 labelSize = CGSizeMake(labelSize.width - 1, labelSize.height);
                 totalLabelsSize = self.indexLabels.count * labelSize.width;
             }
             
-            positionOffset = self.frame.size.width / 2 - totalLabelsSize / 2 - 2;
+            positionOffset = self.bounds.size.width / 2 - totalLabelsSize / 2 - 2;
             break;
         case BDKCollectionIndexViewDirectionVertical:
             dimension = CGRectGetWidth(self.frame);
             if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
                 labelSize = CGSizeMake(dimension, dimension - 6);
             } else {
-                labelSize = CGSizeMake(dimension, dimension - 2);
+                labelSize = CGSizeMake(dimension, dimension);
             }
             totalLabelsSize = self.indexLabels.count * labelSize.height;
             
-            while (totalLabelsSize > self.frame.size.height) {
+            while (totalLabelsSize > self.bounds.size.height) {
                 labelSize = CGSizeMake(labelSize.width, labelSize.height - 1);
                 totalLabelsSize = self.indexLabels.count * labelSize.height;
             }
             
-            positionOffset = self.frame.size.height / 2 - totalLabelsSize / 2 - 6;
+            positionOffset = self.bounds.size.height / 2 - totalLabelsSize / 2 - 1;
             break;
     }
     

--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -54,6 +54,7 @@
 	currentIndex = _currentIndex,
 	touchStatusBackgroundColor = _touchStatusBackgroundColor,
     touchStatusViewAlpha = _touchStatusViewAlpha,
+    font = _font,
     direction = _direction;
 
 + (instancetype)indexViewWithFrame:(CGRect)frame indexTitles:(NSArray *)indexTitles {
@@ -211,9 +212,9 @@
     CGFloat dimension;
     switch (_direction) {
         case BDKCollectionIndexViewDirectionHorizontal:
-            dimension = CGRectGetHeight(self.frame);
+            dimension = CGRectGetHeight(self.bounds);
         case BDKCollectionIndexViewDirectionVertical:
-            dimension = CGRectGetWidth(self.frame);
+            dimension = CGRectGetWidth(self.bounds);
     }
 	
     _touchStatusView.layer.cornerRadius = dimension / 2;
@@ -236,6 +237,17 @@
     return self.indexTitles[self.currentIndex];
 }
 
+- (UIFont *)font {
+    return _font ? _font : [UIFont boldSystemFontOfSize:12.0f];
+}
+
+- (void)setFont:(UIFont *)font {
+    _font = font;
+    for (UILabel *label in self.indexLabels) {
+        label.font = font;
+    }
+}
+
 #pragma mark - Subviews
 
 - (void)buildIndexLabels {
@@ -246,7 +258,7 @@
         label.text = indexTitle;
         label.tag = tag;
         tag = tag + 1;
-        label.font = [UIFont boldSystemFontOfSize:12];
+        label.font = self.font;
         label.backgroundColor = self.backgroundColor;
         label.textColor = self.tintColor;
         label.textAlignment = NSTextAlignmentCenter;


### PR DESCRIPTION
Fix #23.

I did tweak some offset constants to make it look better (at least in vertical-mode) when there are not enough space. Here's a before-after screenshot:

![ios simulator screen shot apr 10 2015 8 40 51 pm](https://cloud.githubusercontent.com/assets/4293969/7093515/8ef99676-dfc2-11e4-8f23-faec8f2ccf52.png)

Ideally, it should also have an option to automatically adjust all labels' font to fit. But being able to manually set font depending on your data is better than nothing. :)