### PR TITLE
Allow points outside frame to trigger changes

### DIFF
--- a/BDKCollectionIndexView.m
+++ b/BDKCollectionIndexView.m
@@ -273,10 +273,28 @@
 - (void)setNewIndexForPoint:(CGPoint)point {
     NSInteger newIndex = -1;
     
+    BOOL (^matchesPoint)(UIView *) = ^(UIView *view) { return YES; };
+    
+    switch (_direction) {
+        case BDKCollectionIndexViewDirectionHorizontal:
+            matchesPoint = ^BOOL(UIView *view) {
+                return (point.x >= CGRectGetMinX(view.frame) &&
+                        point.x <= CGRectGetMaxX(view.frame));
+            };
+            break;
+            
+        case BDKCollectionIndexViewDirectionVertical:
+            matchesPoint = ^BOOL(UIView *view) {
+                return (point.y >= CGRectGetMinY(view.frame) &&
+                        point.y <= CGRectGetMaxY(view.frame));
+            };
+            break;
+    }
+    
     for (UILabel *view in self.indexLabels) {
-		if (!CGRectContainsPoint(view.frame, point)) { continue; }
-		newIndex = view.tag;
-		break;
+        if (!matchesPoint(view)) { continue; }
+        newIndex = view.tag;
+        break;
     }
     
     if (newIndex == -1) {


### PR DESCRIPTION
The previous implementation used CGRectContainsPoint, however the system implementation allows you to move your finger around on the screen after starting the gesture.

This allows the same behavior by just checking the interesting part of the point (x for horizontal, y for vertical) instead of both x and y.

This fixes #26.